### PR TITLE
moved CTEs in session_purchase_facts and user_purchase_facts to separate view objects

### DIFF
--- a/views/session_contains_search.view.lkml
+++ b/views/session_contains_search.view.lkml
@@ -1,0 +1,26 @@
+view: session_contains_search {
+  derived_table: {
+    datagroup_trigger: ecommerce_etl
+    publish_as_db_view: yes
+    sql:
+     select
+       session_purchase.session_id,
+       sum(case when sessions.traffic_source = 'Adwords' then 1 else 0 end) as search_sessions
+     from ${session_purchase.SQL_TABLE_NAME} as session_purchase
+     join ${sessions.SQL_TABLE_NAME}  as sessions
+     on session_purchase.session_user_id = sessions.session_user_id and sessions.session_start >= session_purchase.purchase_session_start and sessions.session_end <= session_purchase.session_end
+     group by 1
+    ;;
+  }
+
+  dimension: session_id {
+    primary_key: yes
+    type: string
+    sql: ${TABLE}.session_id ;;
+  }
+
+  dimension: search_sessions {
+    type: number
+    sql: ${TABLE}.search_sessions ;;
+  }
+}

--- a/views/session_purchase.view.lkml
+++ b/views/session_purchase.view.lkml
@@ -1,0 +1,110 @@
+view: session_purchase {
+  derived_table: {
+    datagroup_trigger: ecommerce_etl
+    publish_as_db_view: yes
+    sql:
+      select
+      coalesce(session_rank - lag(session_rank) over(partition by session_user_id order by session_end), session_rank) as sessions_till_purchase
+      , session_rank as rank
+      , rank() over (partition by session_user_id order by session_end) as session_purchase_rank
+      , lag(session_end) over(partition by session_user_id order by session_end) as purchase_session_start
+      ,*
+      from ${sessions.SQL_TABLE_NAME}
+      where purchase_events > 0
+      order by session_user_id, session_rank
+    ;;
+  }
+
+  dimension: session_id {
+    primary_key: yes
+    type: string
+    sql: ${TABLE}.session_id ;;
+  }
+
+  dimension: sessions_till_purchase {
+    type: number
+    sql: ${TABLE}.sessions_till_purchase ;;
+  }
+
+  dimension: session_purchase_rank {
+    view_label: "Sessions"
+    type: number
+    sql: ${TABLE}.session_purchase_rank ;;
+  }
+
+  dimension_group: session_end {
+    type: time
+    view_label: "Sessions"
+    label: "Purchase End Session"
+    timeframes: [raw, time, date, week, month]
+    sql: ${TABLE}.session_end ;;
+  }
+
+  dimension_group: session_start {
+    type: time
+    timeframes: [raw, time, date, week, month]
+    sql: ${TABLE}.session_start ;;
+  }
+
+  dimension: session_user_id {
+    type: number
+    sql: ${TABLE}.session_user_id ;;
+  }
+
+  dimension: traffic_source {
+    type: string
+  }
+
+  dimension: ad_event_id {
+    type: number
+  }
+
+  dimension: session_rank {
+    type: number
+    sql: ${TABLE}.session_rank ;;
+  }
+
+  dimension: purchase_rank {
+    type: number
+    sql: ${TABLE}.purchase_rank ;;
+  }
+
+  dimension: session_type {
+    description: "Used for Pivots"
+    type: string
+    sql: 'All' ;;
+  }
+
+  dimension: landing_event_id {
+    sql: ${TABLE}.landing_event_id ;;
+  }
+
+  dimension: bounce_event_id {
+    sql: ${TABLE}.bounce_event_id ;;
+  }
+
+  dimension: number_of_browse_events_in_session {
+    type: number
+    sql: ${TABLE}.browse_events ;;
+  }
+
+  dimension: number_of_product_events_in_session {
+    type: number
+    sql: ${TABLE}.product_events ;;
+  }
+
+  dimension: number_of_cart_events_in_session {
+    type: number
+    sql: ${TABLE}.cart_events ;;
+  }
+
+  dimension: number_of_purchase_events_in_session {
+    type: number
+    sql: ${TABLE}.purchase_events ;;
+  }
+
+  dimension: number_of_events_in_session {
+    type: number
+    sql: ${TABLE}.number_of_events_in_session ;;
+  }
+}

--- a/views/user_product_sales.view.lkml
+++ b/views/user_product_sales.view.lkml
@@ -1,0 +1,34 @@
+view: user_product_sales {
+  derived_table: {
+    datagroup_trigger: ecommerce_etl
+    sql:
+    select user_id, product_category, sum(sale_price) as product_sales, row_number() over(PARTITION BY user_id order by sum(sale_price ) desc ) as category_rank
+      from looker-private-demo.ecomm.order_items
+      join looker-private-demo.ecomm.inventory_items
+      on order_items.inventory_item_id = inventory_items.id
+      join looker-private-demo.ecomm.products
+      on inventory_items.product_id = products.id
+      group by 1,2
+       ;;
+  }
+
+  dimension: user_id {
+    type: number
+    sql: ${TABLE}.user_id ;;
+  }
+
+  dimension: product_category {
+    type: string
+    sql: ${TABLE}.product_category ;;
+  }
+
+  dimension: product_sales {
+    type: number
+    sql: ${TABLE}.product_sales ;;
+  }
+
+  dimension: category_rank {
+    type: number
+    sql: ${TABLE}.category_rank ;;
+  }
+}

--- a/views/user_purchase_facts.view.lkml
+++ b/views/user_purchase_facts.view.lkml
@@ -2,17 +2,8 @@ view: user_purchase_facts {
   derived_table: {
     datagroup_trigger: ecommerce_etl
     sql:
-    with user_product_sales as (
-    select user_id, product_category, sum(sale_price) as product_sales, row_number() over(PARTITION BY user_id order by sum(sale_price ) desc ) as category_rank
-      from looker-private-demo.ecomm.order_items
-      join looker-private-demo.ecomm.inventory_items
-      on order_items.inventory_item_id = inventory_items.id
-      join looker-private-demo.ecomm.products
-      on inventory_items.product_id = products.id
-      group by 1,2)
-
       select user_id, product_category as preferred_category
-      from user_product_sales
+      from ${user_product_sales.SQL_TABLE_NAME}
       where category_rank = 1
        ;;
   }


### PR DESCRIPTION
Per [this Slack thread](https://looker.slack.com/archives/CQQDS9F16/p1592592069050000), I took the SQL syntax from CTEs (session_purchase_facts and user_purchase_facts) and created a secondary derived table, then referenced that secondary derived table from the original derived table using ${derived_table_or_view_name.SQL_TABLE_NAME} syntax.